### PR TITLE
Support writing to stdout in cat command

### DIFF
--- a/app/App/Commands/Cat.hs
+++ b/app/App/Commands/Cat.hs
@@ -5,11 +5,10 @@ module App.Commands.Cat
 import App.Commands.Options.Type
 import Control.Lens
 import Data.Semigroup            ((<>))
-import Options.Applicative       hiding (columns)
+import Options.Applicative
 
-import qualified App.IO               as IO
-import qualified App.Lens             as L
-import qualified Data.ByteString.Lazy as LBS
+import qualified App.IO   as IO
+import qualified App.Lens as L
 
 runCat :: CatOptions -> IO ()
 runCat opts = do
@@ -18,7 +17,7 @@ runCat opts = do
 
   contents <- IO.readInputFile source
 
-  LBS.writeFile target contents
+  IO.writeOutputFile target contents
 
   return ()
 
@@ -28,11 +27,15 @@ optsCat = CatOptions
         (   long "input"
         <>  help "Input file"
         <>  metavar "FILE"
+        <>  showDefault
+        <>  value "-"
         )
   <*> strOption
         (   long "output"
         <>  help "Output file"
         <>  metavar "FILE"
+        <>  showDefault
+        <>  value "-"
         )
 
 cmdCat :: Mod CommandFields (IO ())

--- a/app/App/IO.hs
+++ b/app/App/IO.hs
@@ -21,3 +21,7 @@ openOutputFile filePath maybeBufferSize = allocate open close
 readInputFile :: FilePath -> IO LBS.ByteString
 readInputFile "-"      = LBS.hGetContents IO.stdin
 readInputFile filePath = LBS.readFile filePath
+
+writeOutputFile :: FilePath -> LBS.ByteString -> IO ()
+writeOutputFile "-"      bs = LBS.hPut IO.stdout bs
+writeOutputFile filePath bs = LBS.writeFile filePath bs


### PR DESCRIPTION
Properly implement `cat` command to determine the theoretical upper-bound imposed by IO.

```
$ cat 7g.csv | pv -t -e -b -a | hw-dsv cat > /dev/null
7.08GiB 0:00:05 [1.39GiB/s]
```
