### PR TITLE
New simd option for cat command.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -17,7 +17,7 @@
       "taskName": "stack build",
       "isBuildCommand": true,
       "args": [
-        "echo START_STACK_BUILD && cd ${workspaceRoot} && stack build --flag bits-extra:bmi2 --flag hw-bits:sse42 --flag hw-rankselect-base:bmi2 --flag hw-rankselect:bmi2 --flag hw-dsv:bmi2 && echo END_STACK_BUILD "
+        "echo START_STACK_BUILD && cd ${workspaceRoot} && stack build --flag bits-extra:bmi2 --flag hw-rankselect-base:bmi2 --flag hw-rankselect:bmi2 --flag hw-dsv:bmi2 --flag hw-dsv:avx512 && echo END_STACK_BUILD "
       ],
       "problemMatcher": {
         "owner": "haskell",
@@ -56,9 +56,9 @@
     },
     {
       "isTestCommand": true,
-      "taskName": "stack build --flag bits-extra:bmi2 --flag hw-bits:sse42 --flag hw-rankselect-base:bmi2 --flag hw-rankselect:bmi2 --flag hw-dsv:bmi2",
+      "taskName": "stack build --flag bits-extra:bmi2 --flag hw-rankselect-base:bmi2 --flag hw-rankselect:bmi2 --flag hw-dsv:bmi2 --flag hw-dsv:avx512",
       "args": [
-        "echo START_STACK_TEST && cd ${workspaceRoot} && stack test --flag bits-extra:bmi2 --flag hw-bits:sse42 --flag hw-rankselect-base:bmi2 --flag hw-rankselect:bmi2 --flag hw-dsv:bmi2 && echo END_STACK_TEST "
+        "echo START_STACK_TEST && cd ${workspaceRoot} && stack test --flag bits-extra:bmi2 --flag hw-rankselect-base:bmi2 --flag hw-rankselect:bmi2 --flag hw-dsv:bmi2 --flag hw-dsv:avx512 --flag hw-dsv:bmi2 && echo END_STACK_TEST "
       ],
       "problemMatcher": {
         "owner": "haskell",

--- a/app/App/Commands/Cat.hs
+++ b/app/App/Commands/Cat.hs
@@ -7,19 +7,28 @@ import Control.Lens
 import Data.Semigroup            ((<>))
 import Options.Applicative
 
-import qualified App.IO   as IO
-import qualified App.Lens as L
+import qualified App.IO                                                as IO
+import qualified App.Lens                                              as L
+import qualified Data.ByteString                                       as BS
+import qualified Data.ByteString.Lazy                                  as LBS
+import qualified HaskellWorks.Data.Dsv.Internal.Simd.Avx512.ByteString as AVX512BS
+
+runCatNormal :: CatOptions -> IO ()
+runCatNormal opts = do
+  contents <- IO.readInputFile (opts ^. L.source)
+
+  IO.writeOutputFile (opts ^. L.target) ((LBS.fromChunks . fmap BS.copy . LBS.toChunks) contents)
+
+runCatSimd :: CatOptions -> IO ()
+runCatSimd opts = do
+  contents <- IO.readInputFile (opts ^. L.source)
+
+  IO.writeOutputFile (opts ^. L.target) ((LBS.fromChunks . fmap AVX512BS.copy . LBS.toChunks) contents)
 
 runCat :: CatOptions -> IO ()
-runCat opts = do
-  let source = opts ^. L.source
-  let target = opts ^. L.target
-
-  contents <- IO.readInputFile source
-
-  IO.writeOutputFile target contents
-
-  return ()
+runCat opts
+  | opts ^. L.simd  = runCatSimd   opts
+  | otherwise       = runCatNormal opts
 
 optsCat :: Parser CatOptions
 optsCat = CatOptions
@@ -36,6 +45,10 @@ optsCat = CatOptions
         <>  metavar "FILE"
         <>  showDefault
         <>  value "-"
+        )
+  <*> switch
+        (   long "simd"
+        <>  help "Use simd method"
         )
 
 cmdCat :: Mod CommandFields (IO ())

--- a/app/App/Commands/Options/Type.hs
+++ b/app/App/Commands/Options/Type.hs
@@ -24,6 +24,7 @@ data GenerateOptions = GenerateOptions
 data CatOptions = CatOptions
   { _catOptionsSource :: FilePath
   , _catOptionsTarget :: FilePath
+  , _catOptionsSimd   :: Bool
   } deriving (Eq, Show)
 
 data QueryLazyOptions = QueryLazyOptions

--- a/cbits/simd.c
+++ b/cbits/simd.c
@@ -1,0 +1,48 @@
+#include "simd.h"
+
+#include <immintrin.h>
+#include <mmintrin.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <ctype.h>
+
+typedef uint8_t v32si __attribute__ ((vector_size (32)));
+
+void system_memcpy(
+    char *target,
+    char *source,
+    size_t len) {
+  memcpy(target, source, len);
+}
+
+#if defined(AVX512_ENABLED)
+void avx512_memcpy(
+    uint8_t *target,
+    uint8_t *source,
+    size_t len) {
+  size_t aligned_len    = (len / 32) * 32;
+  size_t remaining_len  = len - aligned_len;
+
+  for (size_t i = 0; i < aligned_len; i += 32) {
+    __m256i v = _mm256_maskz_loadu_epi8(0xffffffff, source + i);
+
+    _mm256_mask_storeu_epi8 (target + i, 0xffffffff, v);
+  }
+
+  memcpy(target + aligned_len, source + aligned_len, remaining_len);
+}
+
+#endif
+
+int example_main() {
+  uint8_t source[32] = "01234567890123456789012345678901";
+  uint8_t target[33];
+  avx512_memcpy(target, source, 32);
+  target[32] = 0;
+  printf("%s\n", target);
+
+  return 0;
+}

--- a/cbits/simd.h
+++ b/cbits/simd.h
@@ -1,0 +1,7 @@
+#include <unistd.h>
+#include <stdint.h>
+
+void avx512_memcpy(
+    uint8_t *target,
+    uint8_t *source,
+    size_t len);

--- a/circle.yml
+++ b/circle.yml
@@ -98,6 +98,10 @@ jobs:
           name: Running tests against latest on hackage
           command: stack --stack-yaml stack-ci.yaml test
 
+      - run:
+          name: Check package
+          command: stack exec cabal check
+
       - deploy:
           command: |
             if [ "$CIRCLE_PROJECT_USERNAME" == "haskell-works" ]; then

--- a/hw-dsv.cabal
+++ b/hw-dsv.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 625c09afefb55020df478be91e227d2d299e99d7f734fce5e5be61c7b5a0b64c
+-- hash: a569dda98e2ca42e3bb5d01433254f11aef9693abe16d67c1243146d1990d569
 
 name:           hw-dsv
 version:        0.2.1
@@ -20,6 +20,7 @@ tested-with:    GHC == 8.4.3, GHC == 8.2.2, GHC == 8.0.2, GHC == 7.10.3
 build-type:     Simple
 cabal-version:  >= 1.10
 extra-source-files:
+    cbits/simd.h
     ChangeLog.md
     data/bench/data-0001000.csv
     README.md
@@ -27,6 +28,11 @@ extra-source-files:
 source-repository head
   type: git
   location: https://github.com/haskell-works/hw-dsv
+
+flag avx512
+  description: Enable avx512 instruction set
+  manual: False
+  default: False
 
 flag bmi2
   description: Enable bmi2 instruction set
@@ -44,6 +50,9 @@ library
       HaskellWorks.Data.Dsv.Internal.Broadword
       HaskellWorks.Data.Dsv.Internal.Char
       HaskellWorks.Data.Dsv.Internal.Char.Word64
+      HaskellWorks.Data.Dsv.Internal.Simd.Avx512.ByteString
+      HaskellWorks.Data.Dsv.Internal.Simd.Capabilities
+      HaskellWorks.Data.Dsv.Internal.Simd.Foreign
       HaskellWorks.Data.Dsv.Lazy.Cursor
       HaskellWorks.Data.Dsv.Lazy.Cursor.Internal
       HaskellWorks.Data.Dsv.Lazy.Cursor.Type
@@ -56,6 +65,10 @@ library
   hs-source-dirs:
       src
   ghc-options: -O2 -Wall
+  include-dirs:
+      cbits
+  c-sources:
+      cbits/simd.c
   build-depends:
       base >=4.7 && <5
     , bits-extra >=0.0.1.2 && <0.1
@@ -66,10 +79,20 @@ library
     , hw-rankselect >=0.12.0.2 && <0.13
     , hw-rankselect-base >=0.3.2.0 && <0.4
     , vector >=0.12.0.1 && <0.13
+  build-tools:
+      c2hs
   if flag(sse42)
     ghc-options: -msse4.2
+    cc-options: -msse4.2
+  if flag(bmi2)
+    cc-options: -mbmi2 -DBMI2_ENABLED
   if (flag(bmi2)) && (impl(ghc >=8.4.1))
     ghc-options: -mbmi2 -msse4.2
+  if flag(avx512)
+    cc-options: -mavx512bw -mavx512vl -DAVX512_ENABLED
+  if (flag(avx512)) && (impl(ghc >=8.4.1))
+    ghc-options: -mbmi2 -msse4.2
+    cpp-options: -DBMI2_ENABLED -DAVX512_ENABLED
   if (impl(ghc >=8.0.1))
     ghc-options: -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   if (!impl(ghc >=8.0.1))
@@ -113,8 +136,16 @@ executable hw-dsv
     , vector >=0.12.0.1 && <0.13
   if flag(sse42)
     ghc-options: -msse4.2
+    cc-options: -msse4.2
+  if flag(bmi2)
+    cc-options: -mbmi2 -DBMI2_ENABLED
   if (flag(bmi2)) && (impl(ghc >=8.4.1))
     ghc-options: -mbmi2 -msse4.2
+  if flag(avx512)
+    cc-options: -mavx512bw -mavx512vl -DAVX512_ENABLED
+  if (flag(avx512)) && (impl(ghc >=8.4.1))
+    ghc-options: -mbmi2 -msse4.2
+    cpp-options: -DBMI2_ENABLED -DAVX512_ENABLED
   if (impl(ghc >=8.0.1))
     ghc-options: -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   if (!impl(ghc >=8.0.1))
@@ -146,8 +177,16 @@ test-suite hw-dsv-space
     , weigh >=0.0.6 && <0.1
   if flag(sse42)
     ghc-options: -msse4.2
+    cc-options: -msse4.2
+  if flag(bmi2)
+    cc-options: -mbmi2 -DBMI2_ENABLED
   if (flag(bmi2)) && (impl(ghc >=8.4.1))
     ghc-options: -mbmi2 -msse4.2
+  if flag(avx512)
+    cc-options: -mavx512bw -mavx512vl -DAVX512_ENABLED
+  if (flag(avx512)) && (impl(ghc >=8.4.1))
+    ghc-options: -mbmi2 -msse4.2
+    cpp-options: -DBMI2_ENABLED -DAVX512_ENABLED
   if (impl(ghc >=8.0.1))
     ghc-options: -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   if (!impl(ghc >=8.0.1))
@@ -188,8 +227,16 @@ test-suite hw-dsv-test
     , vector >=0.12.0.1 && <0.13
   if flag(sse42)
     ghc-options: -msse4.2
+    cc-options: -msse4.2
+  if flag(bmi2)
+    cc-options: -mbmi2 -DBMI2_ENABLED
   if (flag(bmi2)) && (impl(ghc >=8.4.1))
     ghc-options: -mbmi2 -msse4.2
+  if flag(avx512)
+    cc-options: -mavx512bw -mavx512vl -DAVX512_ENABLED
+  if (flag(avx512)) && (impl(ghc >=8.4.1))
+    ghc-options: -mbmi2 -msse4.2
+    cpp-options: -DBMI2_ENABLED -DAVX512_ENABLED
   if (impl(ghc >=8.0.1))
     ghc-options: -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   if (!impl(ghc >=8.0.1))
@@ -224,8 +271,16 @@ benchmark bench
     , vector >=0.12.0.1 && <0.13
   if flag(sse42)
     ghc-options: -msse4.2
+    cc-options: -msse4.2
+  if flag(bmi2)
+    cc-options: -mbmi2 -DBMI2_ENABLED
   if (flag(bmi2)) && (impl(ghc >=8.4.1))
     ghc-options: -mbmi2 -msse4.2
+  if flag(avx512)
+    cc-options: -mavx512bw -mavx512vl -DAVX512_ENABLED
+  if (flag(avx512)) && (impl(ghc >=8.4.1))
+    ghc-options: -mbmi2 -msse4.2
+    cpp-options: -DBMI2_ENABLED -DAVX512_ENABLED
   if (impl(ghc >=8.0.1))
     ghc-options: -Wcompat -Wincomplete-record-updates -Wincomplete-uni-patterns -Wredundant-constraints
   if (!impl(ghc >=8.0.1))

--- a/package.yaml
+++ b/package.yaml
@@ -10,6 +10,7 @@ extra-source-files:
 - README.md
 - ChangeLog.md
 - data/bench/data-0001000.csv
+- cbits/simd.h
 
 # Metadata used when publishing your package
 synopsis:            Unbelievably fast streaming DSV file parser
@@ -35,6 +36,12 @@ dependencies:
 
 library:
   source-dirs: src
+  build-tools:
+  - c2hs
+  c-sources:
+  - cbits/simd.c
+  include-dirs:
+  - cbits
 
 executables:
   hw-dsv:
@@ -97,12 +104,30 @@ ghc-options:
 
 when:
 - condition: flag(sse42)
+  cc-options:
+  - -msse4.2
   ghc-options:
   - -msse4.2
+- condition: flag(bmi2)
+  cc-options:
+  - -mbmi2
+  - -DBMI2_ENABLED
 - condition: (flag(bmi2)) && (impl(ghc >=8.4.1))
   ghc-options:
   - -mbmi2
   - -msse4.2
+- condition:  flag(avx512)
+  cc-options:
+  - -mavx512bw
+  - -mavx512vl
+  - -DAVX512_ENABLED
+- condition: (flag(avx512)) && (impl(ghc >=8.4.1))
+  ghc-options:
+  - -mbmi2
+  - -msse4.2
+  cpp-options:
+  - -DBMI2_ENABLED
+  - -DAVX512_ENABLED
 - condition: (impl(ghc >=8.0.1))
   ghc-options:
   - -Wcompat
@@ -122,5 +147,10 @@ flags:
 
   bmi2:
     description: Enable bmi2 instruction set
+    manual: false
+    default: false
+
+  avx512:
+    description: Enable avx512 instruction set
     manual: false
     default: false

--- a/src/HaskellWorks/Data/Dsv/Internal/Simd/Avx512/ByteString.hs
+++ b/src/HaskellWorks/Data/Dsv/Internal/Simd/Avx512/ByteString.hs
@@ -1,0 +1,14 @@
+{-# LANGUAGE CPP #-}
+
+module HaskellWorks.Data.Dsv.Internal.Simd.Avx512.ByteString where
+
+import Foreign.Ptr (castPtr, plusPtr)
+
+import qualified Data.ByteString                             as BS
+import qualified Data.ByteString.Internal                    as BSI
+import qualified Foreign.ForeignPtr                          as F
+import qualified HaskellWorks.Data.Dsv.Internal.Simd.Foreign as F
+
+copy :: BS.ByteString -> BS.ByteString
+copy (BSI.PS x s l) = BSI.unsafeCreate l $ \p -> F.withForeignPtr x $ \f ->
+  F.avx512Memcpy (castPtr p) (f `plusPtr` s) (fromIntegral l)

--- a/src/HaskellWorks/Data/Dsv/Internal/Simd/Capabilities.hs
+++ b/src/HaskellWorks/Data/Dsv/Internal/Simd/Capabilities.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE CPP #-}
+
+module HaskellWorks.Data.Dsv.Internal.Simd.Capabilities where
+
+requireAvx512 :: a -> a
+requireAvx512 a = if avx512Enabled then a else error "AVX512 not enabled"
+{-# INLINE requireAvx512 #-}
+
+avx512Enabled :: Bool
+#if defined(AVX512_ENABLED)
+avx512Enabled = True
+#else
+avx512Enabled = False
+#endif
+{-# INLINE avx512Enabled #-}

--- a/src/HaskellWorks/Data/Dsv/Internal/Simd/Foreign.chs
+++ b/src/HaskellWorks/Data/Dsv/Internal/Simd/Foreign.chs
@@ -1,0 +1,13 @@
+{-# LANGUAGE CPP #-}
+
+module HaskellWorks.Data.Dsv.Internal.Simd.Foreign where
+
+import Foreign
+import Foreign.C.Types
+import HaskellWorks.Data.Dsv.Internal.Simd.Capabilities
+
+#include "../cbits/simd.h"
+
+avx512Memcpy :: Ptr CUChar -> Ptr CUChar -> CULong -> IO ()
+avx512Memcpy target source len = requireAvx512 $ {#call unsafe avx512_memcpy as c_build_ibs#} target source len
+{-# INLINE avx512Memcpy #-}


### PR DESCRIPTION
This example shows `simd` based `memcpy` is `25%` faster.

```
$ cat 7g.csv | pv -t -e -b -a | hw-dsv cat > a.txt
7.08GiB 0:00:12 [ 597MiB/s]
$ cat 7g.csv | pv -t -e -b -a | hw-dsv cat --simd > b.txt
7.08GiB 0:00:09 [ 753MiB/s]
```

Further testing shows `simd` is not actually faster, but also no slower.