### PR TITLE
Fused indexer

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ dependencies:
 - bits-extra            >= 0.0.1.2  && < 0.1
 - bytestring            >= 0.10     && < 0.11
 - deepseq               >= 1.4      && < 1.5
+- ghc-prim
 - hw-bits               >= 0.7.0.2  && < 0.8
 - hw-rankselect         >= 0.12.0.2 && < 0.13
 - hw-rankselect-base    >= 0.3.2.0  && < 0.4

--- a/src/HaskellWorks/Data/Dsv/Internal/Vector.hs
+++ b/src/HaskellWorks/Data/Dsv/Internal/Vector.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module HaskellWorks.Data.Dsv.Internal.Vector where
+
+import Control.Monad.ST
+import Data.Bits.Pdep
+import Data.Word
+import Foreign.Storable                          (Storable)
+import GHC.Int
+import GHC.Prim
+import GHC.Word                                  hiding (ltWord)
+import HaskellWorks.Data.Bits.BitWise
+import HaskellWorks.Data.Bits.PopCount.PopCount1
+import HaskellWorks.Data.Positioning
+
+import qualified Data.Vector.Storable         as DVS
+import qualified Data.Vector.Storable.Mutable as DVSM
+
+constructNS :: forall a s. Storable a => Int -> s -> (s -> DVS.Vector a -> (s, a)) -> (s, DVS.Vector a)
+constructNS n s f = DVS.createT (go 0 s)
+  where go :: forall q. Int -> s -> ST q (s, DVS.MVector q a)
+        go n1 s1 = do
+          mv :: DVS.MVector q a <- DVSM.unsafeNew n
+          u <- DVS.unsafeFreeze mv
+          let (s2, w) = f s1 (DVS.take n1 u)
+          DVSM.unsafeWrite mv n1 w
+          return (s2, mv)
+{-# INLINE constructNS #-}
+
+ltWord :: Word64 -> Word64 -> Word64
+ltWord (W64# a#) (W64# b#) = fromIntegral (I64# (ltWord# a# b#))
+{-# INLINE ltWord #-}
+
+indexCsvChunk ::
+     Count
+  -> Word64
+  -> DVS.Vector Word64
+  -> DVS.Vector Word64
+  -> DVS.Vector Word64
+  -> (DVS.Vector Word64, DVS.Vector Word64, Word64, Word64)
+indexCsvChunk qqCount qqCarry mks nls qqs = runST $ do
+  tmks <- DVSM.unsafeNew len
+  tnls <- DVSM.unsafeNew len
+  (newCount, newCarry) <- go 0 qqCount qqCarry tmks tnls
+  rmks <- DVS.unsafeFreeze tmks
+  rnls <- DVS.unsafeFreeze tnls
+  return (rmks, rnls, newCount, newCarry)
+  where len = DVS.length mks
+        go :: Int -> Word64 -> Word64 -> DVSM.MVector z Word64 -> DVSM.MVector z Word64 -> ST z (Count, Word64)
+        go i pc carry tmks tnls | i < len = do
+          let qq = DVS.unsafeIndex qqs i
+          let mk = DVS.unsafeIndex mks i
+          let nl = DVS.unsafeIndex nls i
+
+          let enters = pdep (oddsMask .<. (0x1 .&.      pc)) qq
+          let leaves = pdep (oddsMask .<. (0x1 .&. comp pc)) qq
+
+          let compLeaves = comp leaves
+          let preQuoteMask = enters + compLeaves
+          let quoteMask = preQuoteMask + carry
+          let newCarry = preQuoteMask `ltWord` enters
+
+          DVSM.unsafeWrite tmks i ((nl .|. mk) .&. quoteMask)
+          DVSM.unsafeWrite tnls i ( nl         .&. quoteMask)
+
+          go (i + 1) (popCount1 qq + pc) newCarry tmks tnls
+        go _ pc carry _ _ = return (pc, carry)
+{-# INLINE indexCsvChunk #-}
+
+oddsMask :: Word64
+oddsMask = 0x5555555555555555
+{-# INLINE oddsMask #-}

--- a/src/HaskellWorks/Data/Dsv/Lazy/Cursor.hs
+++ b/src/HaskellWorks/Data/Dsv/Lazy/Cursor.hs
@@ -13,19 +13,28 @@ module HaskellWorks.Data.Dsv.Lazy.Cursor
   ) where
 
 import Data.Function
-import GHC.Word                                   (Word8)
-import HaskellWorks.Data.Dsv.Internal.Bits
-import HaskellWorks.Data.Dsv.Lazy.Cursor.Internal
+import Data.Word
+import GHC.Word                                  (Word8)
 import HaskellWorks.Data.Dsv.Lazy.Cursor.Type
 import HaskellWorks.Data.RankSelect.Base.Rank1
 import HaskellWorks.Data.RankSelect.Base.Select1
 import HaskellWorks.Data.Vector.AsVector64s
 import Prelude
 
-import qualified Data.ByteString.Lazy                as LBS
-import qualified Data.Vector                         as DV
-import qualified HaskellWorks.Data.Dsv.Internal.Char as C
-import qualified HaskellWorks.Data.Simd.Comparison   as DVS
+import qualified Data.ByteString.Lazy                  as LBS
+import qualified Data.Vector                           as DV
+import qualified Data.Vector.Storable                  as DVS
+import qualified HaskellWorks.Data.Dsv.Internal.Char   as C
+import qualified HaskellWorks.Data.Dsv.Internal.Vector as DVS
+import qualified HaskellWorks.Data.Simd.Comparison     as DVS
+
+makeIndexes :: [DVS.Vector Word64] -> [DVS.Vector Word64] -> [DVS.Vector Word64] -> ([DVS.Vector Word64], [DVS.Vector Word64])
+makeIndexes ds ns qs = unzip $ go 0 0 ds ns qs
+  where go pc carry (dv:dvs) (nv:nvs) (qv:qvs) =
+          let (dv', nv', pc', carry') = DVS.indexCsvChunk pc carry dv nv qv in
+          (dv', nv'):go pc' carry' dvs nvs qvs
+        go _ _ [] [] [] = []
+        go _ _ _ _ _ = error "Unbalanced inputs"
 
 makeCursor :: Word8 -> LBS.ByteString -> DsvCursor
 makeCursor delimiter lbs = DsvCursor
@@ -38,11 +47,7 @@ makeCursor delimiter lbs = DsvCursor
         ibq = DVS.cmpEqWord8s C.doubleQuote <$> ws
         ibn = DVS.cmpEqWord8s C.newline     <$> ws
         ibd = DVS.cmpEqWord8s delimiter     <$> ws
-        pcq = makeCummulativePopCount ibq
-        ibr = zip2Or ibn ibd
-        qm  = makeQuoteMask ibq pcq
-        ib  = zip2And ibr qm
-        nls = zip2And ibn qm
+        (ib, nls) = makeIndexes ibd ibn ibq
 {-# INLINE makeCursor #-}
 
 snippet :: DsvCursor -> LBS.ByteString


### PR DESCRIPTION
Before:

```
$ cat ~/7g.csv | pv -t -e -b -a | time hw-dsv-2 query-lazy -k 0 -k 1 -d , -e '|' > /dev/null
7.08GiB 0:00:41 [ 174MiB/s]
hw-dsv-2 query-lazy -k 0 -k 1 -d , -e '|' > /dev/null  76.89s user 11.84s system 212% cpu 41.694 total
```

After:

```
$ cat ~/7g.csv | pv -t -e -b -a | time hw-dsv query-lazy -k 0 -k 1 -d , -e '|' > /dev/null
7.08GiB 0:00:39 [ 183MiB/s]
hw-dsv query-lazy -k 0 -k 1 -d , -e '|' > /dev/null  72.39s user 11.13s system 211% cpu 39.518 total
```