### PR TITLE
Upgrade to hw-prim-0.6.2.13 for performance optimisations to asVector64

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -32,7 +32,7 @@ dependencies:
 - hw-bits               >= 0.7.0.2  && < 0.8
 - hw-rankselect         >= 0.12.0.2 && < 0.13
 - hw-rankselect-base    >= 0.3.2.0  && < 0.4
-- hw-prim               >= 0.6.2.12 && < 0.7
+- hw-prim               >= 0.6.2.13 && < 0.7
 - hw-simd               >= 0.1.1.1  && < 0.2
 - vector                >= 0.12.0.1 && < 0.13
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,7 +5,7 @@ packages:
 
 extra-deps:
 - criterion-1.5.0.0
-- hw-prim-0.6.2.12
+- hw-prim-0.6.2.13
 - hw-bits-0.7.0.3
 - hw-rankselect-0.12.0.3
 - hw-simd-0.1.1.1


### PR DESCRIPTION
```
$ cat ~/7g.csv | pv -t -e -b -a | time hw-dsv-2 index-word8s > a.bin
7.08GiB 0:00:15 [ 455MiB/s]
hw-dsv-2 index-word8s > a.bin  16.09s user 4.01s system 126% cpu 15.934 total
$ cat ~/7g.csv | pv -t -e -b -a | time hw-dsv index-word8s > b.bin
7.08GiB 0:00:06 [1.06GiB/s]
hw-dsv index-word8s > b.bin  5.41s user 3.46s system 132% cpu 6.680 total
```