### PR TITLE
Add UndecidableInstances to make GHC 8.6 happy

### DIFF
--- a/src/HaskellWorks/Data/Dsv/Strict/Cursor/Type.hs
+++ b/src/HaskellWorks/Data/Dsv/Strict/Cursor/Type.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE FlexibleContexts   #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 module HaskellWorks.Data.Dsv.Strict.Cursor.Type
   ( DsvCursor(..)


### PR DESCRIPTION
even thought this doesn't get a build plan on GHC 8.6 until https://github.com/hedgehogqa/haskell-hedgehog/pull/224 is merged and released.

Older versions will probably require some revisions which I'll do when it comes up.