### PR TITLE
Pad out the index to ensure the index addresses strictly more bytes t…

### DIFF
--- a/src/HaskellWorks/Data/Dsv/Lazy/Cursor.hs
+++ b/src/HaskellWorks/Data/Dsv/Lazy/Cursor.hs
@@ -33,12 +33,15 @@ import qualified HaskellWorks.Data.Dsv.Internal.Char   as C
 import qualified HaskellWorks.Data.Dsv.Internal.Vector as DVS
 import qualified HaskellWorks.Data.Simd.Comparison     as DVS
 
+empty64 :: DVS.Vector Word64
+empty64 = DVS.replicate 64 0
+
 makeIndexes :: [DVS.Vector Word64] -> [DVS.Vector Word64] -> [DVS.Vector Word64] -> ([DVS.Vector Word64], [DVS.Vector Word64])
 makeIndexes ds ns qs = unzip $ go 0 0 ds ns qs
   where go pc carry (dv:dvs) (nv:nvs) (qv:qvs) =
           let (dv', nv', pc', carry') = DVS.indexCsvChunk pc carry dv nv qv in
           (dv', nv'):go pc' carry' dvs nvs qvs
-        go _ _ [] [] [] = []
+        go _ _ [] [] [] = [(empty64, empty64)]
         go _ _ _ _ _ = error "Unbalanced inputs"
 
 makeCursor :: Word8 -> LBS.ByteString -> DsvCursor

--- a/test/HaskellWorks/Data/Dsv/Lazy/CursorSpec.hs
+++ b/test/HaskellWorks/Data/Dsv/Lazy/CursorSpec.hs
@@ -114,7 +114,7 @@ spec = describe "HaskellWorks.Data.Dsv.Lazy.CursorSpec" $ do
           , "1.0e-2"
           ]
         ]
-    xit "512 bytes" $ requireTest $ do
+    it "512 bytes" $ requireTest $ do
       let actual = testToListList $ LBS.intercalate "\n"
             [ "id,group_id,arm,first_name,last_name,email,contact_number,start_date,status,dose_smart_id,fitbit_id,glyco_id,sms_reminder,email_reminder,inactive_reminder,starting_weight,starting_bmi,starting_hba1c"
             , "10,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,1,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,aaaaaaa,aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa,2018-01-01 00:00:00 UTC,Active,,,,Never,Weekly,Never,100.01,10.01,1.0e-2"


### PR DESCRIPTION
…han exists in the text to fix the bug that on the occasion of the input text being a multiple of 512 bytes, the last field is not returned