### PR TITLE
use 1-based columns for ease of use

### DIFF
--- a/app/App/Commands/QueryLazy.hs
+++ b/app/App/Commands/QueryLazy.hs
@@ -16,6 +16,7 @@ import Control.Monad.Trans.Resource
 import Data.List
 import Data.Semigroup               ((<>))
 import Options.Applicative          hiding (columns)
+import Text.Read                    (readEither)
 
 import qualified App.IO                            as IO
 import qualified App.Lens                          as L
@@ -105,10 +106,17 @@ runQueryLazyFast opts = do
 cmdQueryLazy :: Mod CommandFields (IO ())
 cmdQueryLazy = command "query-lazy" $ flip info idm $ runQueryLazy <$> optsQueryLazy
 
+nonZeroOneBased :: Mod OptionFields Int -> Parser Int
+nonZeroOneBased = option $ eitherReader $ \s -> do
+  a <- readEither s
+  if a == 0
+    then Left "cannot index column 0"
+    else Right (a - 1)
+
 optsQueryLazy :: Parser QueryLazyOptions
 optsQueryLazy = QueryLazyOptions
     <$> many
-        ( option auto
+        ( nonZeroOneBased
           (   long "column"
           <>  short 'k'
           <>  help "Column to select"

--- a/app/App/Commands/QueryStrict.hs
+++ b/app/App/Commands/QueryStrict.hs
@@ -16,6 +16,7 @@ import Control.Monad.Trans.Resource
 import Data.List
 import Data.Semigroup               ((<>))
 import Options.Applicative
+import Text.Read                    (readEither)
 
 import qualified App.IO                              as IO
 import qualified App.Lens                            as L
@@ -52,10 +53,17 @@ runQueryStrict opts = do
 cmdQueryStrict :: Mod CommandFields (IO ())
 cmdQueryStrict = command "query-strict" $ flip info idm $ runQueryStrict <$> optsQueryStrict
 
+nonZeroOneBased :: Mod OptionFields Int -> Parser Int
+nonZeroOneBased = option $ eitherReader $ \s -> do
+  a <- readEither s
+  if a == 0
+    then Left "cannot index column 0"
+    else Right (a - 1)
+
 optsQueryStrict :: Parser QueryStrictOptions
 optsQueryStrict = QueryStrictOptions
     <$> many
-        ( option auto
+        ( nonZeroOneBased
           (   long "column"
           <>  short 'k'
           <>  help "Column to select"


### PR DESCRIPTION
```
% head -n 1 test.csv | tr ',' '\n' | cat -n
     1  "start_ip_int"
     2  "end_ip_int"
     3  "continent"
     4  "country"
```

```
% hw-dsv query-lazy -i test.csv -k 1 -d , -e '|'
"end_ip_int"
"16777216"
"16777472"
```

It's often easier to count from 1.

This change validates that the `--column | -k` arguments are `> 0` and then passes the predecessor of these to the rest of the program.